### PR TITLE
commented out isNameSpaceExportDeclaration import

### DIFF
--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -2,7 +2,7 @@
  *  1 unfinished tests
  */
 
-import { isNamespaceExportDeclaration } from "typescript";
+//import { isNamespaceExportDeclaration } from "typescript";
 
 /**
  * Consume an array of numbers, and return a new array containing


### PR DESCRIPTION
the linter was complaining about the import as it went unused